### PR TITLE
Moved to Notification-Scope

### DIFF
--- a/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenBuildProviderMapObjective.php
+++ b/Services/GlobalScreen/classes/Setup/class.ilGlobalScreenBuildProviderMapObjective.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
 declare(strict_types=1);
 
 use ILIAS\GlobalScreen\Scope\Layout\Provider\ModificationProvider;
@@ -8,20 +24,8 @@ use ILIAS\GlobalScreen\Scope\MetaBar\Provider\StaticMetaBarProvider;
 use ILIAS\GlobalScreen\Scope\Notification\Provider\NotificationProvider;
 use ILIAS\GlobalScreen\Scope\Tool\Provider\DynamicToolProvider;
 use ILIAS\Setup;
+use ILIAS\GlobalScreen\Scope\Toast\Provider\ToastProvider;
 
-/******************************************************************************
- *
- * This file is part of ILIAS, a powerful learning management system.
- *
- * ILIAS is licensed with the GPL-3.0, you should have received a copy
- * of said license along with the source code.
- *
- * If this is not the case or you just want to try ILIAS, you'll find
- * us at:
- *      https://www.ilias.de
- *      https://github.com/ILIAS-eLearning
- *
- *****************************************************************************/
 /**
  * Class ilGSBootLoaderBuilder
  * @package ILIAS\GlobalScreen\BootLoader
@@ -42,6 +46,7 @@ class ilGlobalScreenBuildProviderMapObjective extends Setup\Artifact\BuildArtifa
             DynamicToolProvider::class,
             ModificationProvider::class,
             NotificationProvider::class,
+            ToastProvider::class
         ];
 
         $finder = new Setup\ImplementationOfInterfaceFinder();

--- a/Services/GlobalScreen/classes/class.ilGSProviderFactory.php
+++ b/Services/GlobalScreen/classes/class.ilGSProviderFactory.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This file is part of ILIAS, a powerful learning management system
  * published by ILIAS open source e-Learning e.V.
@@ -17,6 +15,8 @@ declare(strict_types=1);
  * https://github.com/ILIAS-eLearning
  *
  *********************************************************************/
+
+declare(strict_types=1);
 
 use ILIAS\DI\Container;
 use ILIAS\GlobalScreen\Provider\Provider;
@@ -233,7 +233,7 @@ class ilGSProviderFactory implements ProviderFactory
      */
     private function appendCore(array &$array_of_providers, string $interface): void
     {
-        foreach ($this->class_loader[$interface] as $class_name) {
+        foreach ($this->class_loader[$interface] ?? [] as $class_name) {
             if ($this->isInstanceCreationPossible($class_name)) {
                 try {
                     $array_of_providers[] = new $class_name($this->dic);


### PR DESCRIPTION
Hi @iszmais 

Ich habe gedacht es geht am schnellsten, wenn ich das direkt kurz verschiebe: Ich sehe die Toasts nicht als eigenen Scope, habe sie daher in den Scope der Notifications verschoben, dabei aber als eigenständige Providers und Collectors belassen.

Ansonsten habe ich versucht das Collecten etc. alles schon zu implementieren, auch so, dass plugins das direkt auch nutzen können.

Der PR hier ist ungetestet, ich weiss nicht, ob damit dein Einsatzzweck noch funktioniert, das müsstest du kurz ausprobieren :-) Wenn du hier mergest, wird der PR im ILIAS-Repo ja dann aktualisiert. Gerne dort aber dann auch noch einige UnitTest beisteuern, das wäre super!