### PR TITLE
How to add a push provider

### DIFF
--- a/components/ILIAS/Dashboard/classes/class.ilDashboardGUI.php
+++ b/components/ILIAS/Dashboard/classes/class.ilDashboardGUI.php
@@ -263,9 +263,22 @@ class ilDashboardGUI implements ilCtrlBaseClassInterface
         }
         $content .= $this->getCenterColumnHTML();
 
+        global $DIC;
+        $content = $DIC->ui()->renderer()->render(
+            $DIC->ui()->factory()->button()->standard('Notify me!', $this->ctrl->getLinkTarget($this, 'notify')),
+        ) . $content;
+
         $this->tpl->setContent($content);
         $this->tpl->setRightContent($this->getRightColumnHTML());
         $this->tpl->printToStdout();
+    }
+
+    public function notify(): void
+    {
+        $provider = new \ILIAS\Notifications\MyProvider();
+        $handler = new \ILIAS\Notifications\Provider\NotificationsPushProvider($provider);
+        $handler->push($this->user, 'You pushed a button. Congrats!');
+        $this->show();
     }
 
     public function getCenterColumnHTML(): string

--- a/components/ILIAS/Notifications/Notifications.php
+++ b/components/ILIAS/Notifications/Notifications.php
@@ -49,5 +49,7 @@ class Notifications implements Component\Component
             new Component\Resource\OfComponent($this, "receive.mp3", "assets/sounds");
         $contribute[Component\Resource\PublicAsset::class] = fn() =>
             new Component\Resource\OfComponent($this, "receive.ogg", "assets/sounds");
+        $contribute[\ILIAS\Notifications\Interfaces\PushProviderInterface::class] = fn() =>
+            new \ILIAS\Notifications\MyProvider();
     }
 }

--- a/components/ILIAS/Notifications/classes/MyProvider.php
+++ b/components/ILIAS/Notifications/classes/MyProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+declare(strict_types=1);
+
+namespace ILIAS\Notifications;
+
+use ILIAS\Notifications\Interfaces\PushProviderInterface;
+use ilLanguage;
+
+class MyProvider implements PushProviderInterface
+{
+    public function getIdentifier(): string
+    {
+        return 'my_prov1';
+    }
+
+    public function getName(ilLanguage $lng): string
+    {
+        return 'Personal Test Provider';
+    }
+
+    public function getDescription(ilLanguage $lng): string
+    {
+        return 'This is a personal test provider for presentation purposes';
+    }
+}


### PR DESCRIPTION
# How to add a push provider

## Requirements
- ILIAS 11 with a valid ECDH Key (see [doc](https://github.com/iszmais/ILIAS/blob/release_11/components/ILIAS/Notifications/README.md#external-notification))
- A PWA-compatible manifest.json (for IOS).

## Implementation
- Create a provider implementing the `PushProviderInterface`
- Contribute your provider.
- Add the provider to the target workflow

#### Limitations/Considerations

- Some OS or browser may not support notifications out of the box.
- The distribution process is raw and therefore may encounter the following problems
  - No queues ⇒ performance
  - No validations ⇒ spam
  - No heartbeat ⇒ loss

## Usage

#### For Admins
- If installed, you can activate them in `Administration ⇒ Communication ⇒ Notifications ⇒ Push Notifications`

#### For users
- If activated, you can enable them **for this device** in `Communications ⇒ Push Notifications ⇒ Client Settings`
- Further you can select services you want to be notified by **for this account** in `Communications ⇒ Push Notifications ⇒ User Settings`
- You can disable them the same way or within the browser settings.



